### PR TITLE
MNT: Add hepmc3 team to maintainer list 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @chrisburr
+* @chrisburr @conda-forge/hepmc3

--- a/README.md
+++ b/README.md
@@ -340,4 +340,5 @@ Feedstock Maintainers
 =====================
 
 * [@chrisburr](https://github.com/chrisburr/)
+* [@conda-forge/hepmc3](https://github.com/orgs/conda-forge/teams/hepmc3/)
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -85,3 +85,4 @@ about:
 extra:
   recipe-maintainers:
     - chrisburr
+    - conda-forge/hepmc3


### PR DESCRIPTION
Adding @conda-forge/hepmc3 as a maintainers given @chrisburr's suggestion to use @conda-forge/hepmc3 as a metaorg team for [HEP Packaging Coordination](https://github.com/hep-packaging-coordination).

c.f. https://github.com/conda-forge/hepmc3-feedstock/pull/23

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
   - Adding a maintainer doesn't require a rebuild.
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
